### PR TITLE
Increase backed up tables per dataset from 50 (default)

### DIFF
--- a/blogs/bigquery_backup/bigquery_backup.py
+++ b/blogs/bigquery_backup/bigquery_backup.py
@@ -81,7 +81,7 @@ if __name__ == '__main__':
     else:
         dataset = args.input
         dataset_contents = exec_shell_command(
-            ['bq', '--format=json', 'ls', dataset]
+            ['bq', '--format=json', 'ls', '--max_results', '10000', dataset]
         )
         dataset_contents = json.loads(dataset_contents) # array of dicts
         tables = []
@@ -94,4 +94,3 @@ if __name__ == '__main__':
 
     for table in tables:
         backup_table(dataset, table, args.output, args.schema)
-


### PR DESCRIPTION
By default the `bq ls` command will show at most 50 tables. 

If you're using `bigquery_backup.py` for backing up a dataset, it may give you the impression that everything is backed up, whereas in reality it might only be 50 of the tables within the dataset. 

In lieu of an 'all tables' option, I propose increasing the maximum number of listed tables to 10,000. 