### PR TITLE
increase wait time before running the ML query

### DIFF
--- a/blogs/flex_slots/run_query_on_flex_slots.sh
+++ b/blogs/flex_slots/run_query_on_flex_slots.sh
@@ -63,7 +63,7 @@ ASSIGNMENT=$((bq mk --reservation_assignment --reservation_id=${PROJECT}:${LOCAT
 echo ${ASSIGNMENT}
 
 # give the slots about 30 s to get setup
-sleep 30
+sleep 120
 
 run_query || true
 


### PR DESCRIPTION
When I first run the script I got this error : 

> Error in query string: Error processing job : Training Matrix Factorization models is not available for on-demand usage. To train,
please set up a reservation (flex or regular) based on instructions in BigQuery public docs.

I tried different wait time and the script run successfully with 120s